### PR TITLE
fix broken coverage setup

### DIFF
--- a/tns-core-modules/ui/core/view/view.android.ts
+++ b/tns-core-modules/ui/core/view/view.android.ts
@@ -135,8 +135,14 @@ function initializeDialogFragment() {
             this._shownCallback = options.shownCallback;
             this.owner._dialogFragment = this;
             this.setStyle(android.support.v4.app.DialogFragment.STYLE_NO_TITLE, 0);
+            
+            let theme = this.getTheme();
+            if (this._fullscreen) {
+                // In fullscreen mode, get the application's theme.
+                theme = this.getActivity().getApplicationInfo().theme;
+            }
 
-            const dialog = new DialogImpl(this, this.getActivity(), this.getTheme());
+            const dialog = new DialogImpl(this, this.getActivity(), theme);
 
             // do not override alignment unless fullscreen modal will be shown;
             // otherwise we might break component-level layout:


### PR DESCRIPTION
…(#6691)

* set the correct application theme while creating the dialog fragment

* useing the new approche fusing the new approach for setting the theme only when the modal view is fullscreen(it will break the style when using non-fullscreen modal)

* note - get theme change

* set the correct application theme while creating the dialog fragment

* useing the new approche fusing the new approach for setting the theme only when the modal view is fullscreen(it will break the style when using non-fullscreen modal)

* note - get theme change

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

